### PR TITLE
quick and dirty fix to JAVA_HOME when running coana as github action

### DIFF
--- a/vulnerability-analysis/action.yml
+++ b/vulnerability-analysis/action.yml
@@ -31,6 +31,9 @@ inputs:
     description: 'Reachability analysis memory limit (defaults to 8192MB)'
     required: false
 
+- run: echo "JAVA_HOME=" >> $GITHUB_ENV
+- run: echo "KOTLIN_HOME=" >> $GITHUB_ENV
+- run: echo "SCALA_HOME=" >> $GITHUB_ENV
 
 runs:
   using: 'docker'


### PR DESCRIPTION
This PR clears environment variables `JAVA_HOME`, `KOTLIN_HOME`, and `SCALA_HOME` before running the coana action. These environment variables map to file paths in the hosting environment and therefore do not exist inside the coana container.
This should mitigate the issue with an invalid `JAVA_HOME` path when running coana as a github action.

The issue is replicated in the following workflor:
https://github.com/coana-tech/java-home-demo-project/actions/runs/9127585658/workflow

Running the workflow, we get the following error:
```
2024-05-17 11:37:18.215 - error: Error running command: gradle -I /coana/analyzers/coana-gradle-script/coana.init.gradle.kts :coanaWorkspaceList --outputDirectory /tmp/coana-gradle-package-managerXXXXXXpkNmJj --outputFile workspaces.txt
```

Inspecting the output, we can see that environment variables `JAVA_HOME` and `JAVA_HOME_17_X64` are passed on to the coana docker:
```
Run coana-tech/coana-action/vulnerability-analysis@main
  with:
    apiKey: test
    repoUrl: https://github.com/coana-tech/java-home-demo-project
    path: .
    debug: false
    uploadReportArtifact: false
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.11-9/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.11-9/x64
/usr/bin/docker run --name aa8037819d44dae71f49cab3ac67eb3f21117d_92d077 --label aa8037 --workdir /github/workspace --rm -e "JAVA_HOME" -e "JAVA_HOME_17_X64" (...)
```

The fixed workflow file is here:
https://github.com/coana-tech/java-home-demo-project/actions/runs/9128376130/workflow

The fix is by clearing the `JAVA_HOME` environment variable before running the coana action:
`- run: echo "JAVA_HOME=" >> $GITHUB_ENV`